### PR TITLE
ui.py: Helpmenu must de defined before ConfigListScreen.__init__()

### DIFF
--- a/plugin/ui.py
+++ b/plugin/ui.py
@@ -224,6 +224,8 @@ class FontInfoTestLength(Screen, ConfigListScreen):
 
 		self["text"] = Label()
 		self["size"] = Label()
+		self["HelpWindow"] = Pixmap()
+		self["HelpWindow"].hide()
 
 		self.FontInfoTestLengthCfg = []
 		ConfigListScreen.__init__(self, self.FontInfoTestLengthCfg, session=self.session, on_change=self.changes)
@@ -240,8 +242,6 @@ class FontInfoTestLength(Screen, ConfigListScreen):
 		self["key_red"] = Label(_("Cancel"))
 		self["key_yellow"] = Label(_("Clear"))
 		self["key_blue"] = Label(_("Reload"))
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
 		self.onLayoutFinish.append(self.setString)
 


### PR DESCRIPTION
To fix:

raceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 77, in selectionChanged
    x()
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 202, in handleInputHelpers
    helpwindowpos = self["HelpWindow"].getPosition()
  File "/usr/lib/enigma2/python/Components/GUIComponent.py", line 91, in getPosition
    p = self.instance.position()
AttributeError: 'NoneType' object has no attribute 'position'